### PR TITLE
doc: recommend treating CS9057 as error

### DIFF
--- a/docs/logic_blocks/02_installation.md
+++ b/docs/logic_blocks/02_installation.md
@@ -21,6 +21,21 @@ Find the latest version number of LogicBlocks, its diagram generator, and the in
 Don't forget to include the `PrivateAssets="all"` and `OutputItemType="analyzer"` attributes on generator package references.
 :::
 
+:::caution
+We strongly recommend treating warning `CS9057` as an error to catch possible compiler-mismatch issues with the Introspection generator. (See the [Introspection] README for more details.) To do so, add a `WarningsAsErrors` line to your `.csproj` file's `PropertyGroup`:
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net8.0</TargetFramework>
+  ...
+  <!-- Catch compiler-mismatch issues with the Introspection generator -->
+  <WarningsAsErrors>CS9057</WarningsAsErrors>
+  ...
+</PropertyGroup>
+```
+
+:::
+
 :::tip
 Always use the same version of the LogicBlocks diagram generator that you use for LogicBlocks, since they are updated together.
 :::
@@ -29,3 +44,4 @@ Always use the same version of the LogicBlocks diagram generator that you use fo
 [Chickensoft.LogicBlocks.DiagramGenerator]: https://www.nuget.org/packages/Chickensoft.LogicBlocks.DiagramGenerator#versions-body-tab
 [Chickensoft.Introspection.Generator]: https://www.nuget.org/packages/Chickensoft.Introspection.Generator
 [Chickensoft.LogicBlocks]: https://www.nuget.org/packages/Chickensoft.LogicBlocks
+[Introspection]: https://github.com/chickensoft-games/Introspection


### PR DESCRIPTION
## Description

CS9057 is a compiler warning issued when a consuming project is using an earlier version of the .NET compiler than was used to compile the Introspection generator. Such a mismatch can have serious, hard-to-diagnose downstream consequences for users. (See chickensoft-games/Introspection#20 and chickensoft-games/GameDemo#104.) This change updates the documentation to recommend treating CS9057 as an error in consuming projects, to make those issues easier to diagnose and fix.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
