### PR TITLE
Add missing parameters to LogicBlocks Testing Docs

### DIFF
--- a/content/docs/logic_blocks/testing/testing_states.mdx
+++ b/content/docs/logic_blocks/testing/testing_states.mdx
@@ -98,8 +98,8 @@ var state = new Timer.State.PoweredOn.Idle();
 var context = state.CreateFakeContext();
 
 // Simulate the state being attached to a logic block.
-state.Attach();
+state.Attach(context);
 
 // Simulate the state being detached from a logic block.
-state.Detach();
+state.Detach(context);
 ```


### PR DESCRIPTION
Actually trying to use `state.Attach()` required use of a context parameter, so I've fixed the docs accordingly. 