### PR TITLE
Remove rounded image corner in `blog_preview.tsx`

### DIFF
--- a/components/blog_preview/blog_preview.tsx
+++ b/components/blog_preview/blog_preview.tsx
@@ -93,7 +93,7 @@ export default async function BlogPreview(
           <SiteImage
             src={blogPost.data.image}
             alt={blogPost.data.title}
-            className="w-full h-auto"
+            className="w-full h-auto rounded-none"
           />
         </div>
 


### PR DESCRIPTION
Removes the rounded corners from images within blog previews since it looked a bit weird before.

Before:
![image](https://github.com/user-attachments/assets/f045551f-3775-4a16-bc50-f7b40923d68b)

After:
![image](https://github.com/user-attachments/assets/70fede85-ec35-43b4-9896-143f7ebf8dce)
