### PR TITLE
doc: add note about Windows Developer Mode

### DIFF
--- a/content/docs/setup.mdx
+++ b/content/docs/setup.mdx
@@ -245,6 +245,10 @@ If you're using GodotEnv, Godot versions will automatically be installed in the 
 | Symlink     | `C:\Users\{you}\AppData\Roaming\godotenv\godot\bin`                                                                                                       |
 | Actual Path | `C:\Users\{you}\AppData\Roaming\godotenv\godot\versions\godot_dotnet_{version}\Godot_v{version}-stable_mono_win64\Godot_v{version}-stable_mono_win64.exe` |
 
+<Callout type="info">
+In some cases, enabling [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) may be required for GodotEnv to correctly manage symlinks.
+</Callout>
+
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
- add note about Windows sometimes requiring Developer Mode to be enabled for symlinks to be created