### PR TITLE
fix: file-existence check server-side for images

### DIFF
--- a/components/site_image/site_image.tsx
+++ b/components/site_image/site_image.tsx
@@ -1,4 +1,6 @@
 import fs from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
 import { cn } from "fumadocs-ui/components/api";
 import { ImageZoom } from "fumadocs-ui/components/image-zoom";
 import { getImageSize } from "next/dist/server/image-optimizer";
@@ -53,12 +55,9 @@ export default async function SiteImage(
 export async function SiteImageZoom(
   props: SiteImageProps
 ): Promise<JSX.Element> {
-  const path = cwd() + "/public" + props.src;
+  const path = join(process.cwd(), "public", props.src);
 
-  const fileExists = await fs
-    .access(path)
-    .then(() => true)
-    .catch(() => false);
+  const fileExists = existsSync(path);
 
   if (!fileExists) {
     return (


### PR DESCRIPTION
Image zoom isn't working because the file-existence check in the SiteImageZoom component fails in prod. This hopefully fixes the issue by using Node's existsSync() to check for image presence.