### PR TITLE
Update Setup Guide Install Links

### DIFF
--- a/content/docs/setup.mdx
+++ b/content/docs/setup.mdx
@@ -183,7 +183,7 @@ You can use Chickensoft's command-line tool, [GodotEnv], to manage Godot version
 <Callout type="info">
 Using GodotEnv to install and manage Godot on your system provides a number of advantages:
 
-- ✅ Automatically download, extract, and install any requested Godot 4.x+ version (with or without .NET support) from the Godot [TuxFamily] downloads mirror.
+- ✅ Automatically download, extract, and install any requested Godot 4.x+ version (with or without .NET support) from the [GitHub Release Builds][github-godot-release-builds].
 
 - ✅ Automatically manage symlink on your system that point to the version of Godot you'd like to use. The symlink path never changes — just the version it points to.
 
@@ -549,14 +549,14 @@ If you need to share code **and** other resource files like scenes, textures, mu
 <GithubCard owner='chickensoft-games' repo='GodotEnv' logo='/img/chickensoft/godot_env.png'/>
 </Callout>
 
-[download-godot]: https://downloads.tuxfamily.org/godotengine/
+[download-godot]: https://godotengine.org/download/
 [vscode]: https://code.visualstudio.com
 [vs-2022]: https://visualstudio.microsoft.com/downloads/
 [win-env-vars]: https://github.com/sindresorhus/guides/blob/main/set-environment-variables.md#windows-7-and-8
 [GodotEnv]: https://github.com/chickensoft-games/GodotEnv
 [dotnet-sdk]: https://dotnet.microsoft.com/en-us/download/dotnet
 [net8-release-notes]: https://github.com/dotnet/core/blob/main/release-notes/8.0/install-windows.md
-[TuxFamily]: https://downloads.tuxfamily.org/godotengine/
+[github-godot-release-builds]: https://github.com/godotengine/godot-builds/releases
 [git]: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 [git-started]: https://www.atlassian.com/git/tutorials/what-is-version-control
 [GitHub]: https://github.com


### PR DESCRIPTION
## Change List
- update Setup Guide install links
  - update the GodotEnv Godot install source to match the [GodotEnv README](https://github.com/chickensoft-games/GodotEnv/blob/main/README.md):
     > Downloads are made from [GitHub Release Builds](https://github.com/godotengine/godot-builds/releases).
  - update the manual Godot install link to point to the official download page