### PR TITLE
fix: note additional licenses for logo and model

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
       100
     ],
     "editor.wordWrapColumn": 100,
-    "editor.wordWrap": "bounded"
+    "editor.wordWrap": "bounded",
+    "files.trimTrailingWhitespace": false
   },
   "files.exclude": {
     "**/node_modules": true

--- a/app/global.ts
+++ b/app/global.ts
@@ -122,7 +122,7 @@ export const site: SiteData = {
         },
         {
           url: "/license",
-          title: "Open Source Licenses",
+          title: "Licenses",
         },
       ],
     },

--- a/content/pages/license.mdx
+++ b/content/pages/license.mdx
@@ -1,8 +1,10 @@
 ---
-title: Open Source Licenses
+title: Licenses
 image: /img/chickensoft_square.png
 keywords: []
 ---
+
+## Code
 
 All original code in Chickensoft's open source projects is licensed under the permissive [MIT License][mit]. Code that is not original is provided under the license of the original author. Non-original code will have its license provided in the directory of the repository it resides in.
 
@@ -12,19 +14,19 @@ Chickensoft projects will only include code licensed under a permissive license 
 
 ```text
 MIT License
-
+ 
 Copyright (c) 2023 Chickensoft Games
-
+ 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-
+ 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
-
+ 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,5 +36,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
+## Logo
+
+The Chickensoft logo is licensed under the [Creative Commons Attribution-NoDerivatives 4.0 (CC BY-ND 4.0) license][cc-by-nd-4.0]. In short, you may copy and redistribute the logo in any form (on your game's splash screen, for instance), even in commercial projects. However, you must provide attribution to Chickensoft somewhere in your project or credits, and you may not redistribute modified versions of the logo.
+
+## 3D Chickensoft Mascot
+
+The 3D Chickensoft Mascot Model and animations, used in the Game Demo, are under different licenses.
+
+### Chickensoft Mascot Model
+
+The Chickensoft 3D Mascot Model is licensed under the [Creative Commons Attribution 4.0 (CC BY 4.0) license][cc-by-4.0]. In short, this allows you to use, make derivatives, and share your derivatives, even for commercial purposes, so long as you attribute and give credit to Chickensoft somewhere in your project or credits.
+
+Since the Chickensoft mascot represents Chickensoft, we require attribution if you use it for anything other than personal use — that's it!
+
+### Chickensoft Mascot Animations
+
+The Chickensoft 3D Mascot Model animations are licensed under the [CC0 1.0 license][cc0]. This allows you to use, make derivatives, and share your derivatives, even for commercial purposes, without any attribution or credit required.
+
+Why? So that you can re-target the animations to your own similar models and rigs without needing to worry about where you got them from. There need to be more totally free game animations in the world!
+
 [mit]: https://choosealicense.com/licenses/mit/
 [choose-a-license]: https://choosealicense.com/
+[cc-by-nd-4.0]: https://creativecommons.org/licenses/by-nd/4.0/
+[cc-by-4.0]: https://creativecommons.org/licenses/by/4.0/
+[cc0]: https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Updated the licenses page to note CC licenses for the Chickensoft logo and mascot model. Also updated the footer link for the licenses page since CC licenses aren't "open source."

Additionally, markdown processing is currently removing extra line breaks in plain-text fenced blocks and messing up the paragraphing for the MIT license. As a workaround, added spaces to empty lines in the MIT-license fenced block and told VSCode not to remove them.