### PR TITLE
feat: code-quality & AI-use policy

### DIFF
--- a/content/pages/code-of-conduct.mdx
+++ b/content/pages/code-of-conduct.mdx
@@ -8,4 +8,16 @@ The Chickensoft team adheres to the [Contributor Covenant][contributor-covenant]
 
 In general, be kind to others, assume good faith interactions, and avoid making personal remarks. Discrimination of any type is not tolerated. We rely on moderator discretion and do our best to create a positive atmosphere in Discord, on GitHub, and anywhere else we might interact with others.
 
+## Code Quality, Review, and AI Policy
+
+From the *[Chickensoft Technical Philosophy][chickensoft-philosophy]*:
+> Chickensoft believes code quality and developer happiness are core determiners of whether or not a project will be successfully completed on time. [...] All Chickensoft projects exist to serve the classic game development idea of “finding the fun.” [...] Each Chickensoft project is striving to have as little code as is necessary to perform its function in a readable, maintainable manner …
+
+Chickensoft’s purpose is to enable enjoyable game architecture, but we also strive for enjoyable contributions to the Chickensoft ecosystem. To both ends, Chickensoft aims to preserve a high quality standard in our code. Any code contributed to Chickensoft must be approved by our maintainers to ensure it demonstrates utility, clearly expresses intent, and preserves maintainability.
+
+To avoid overwhelming maintainers, submissions that we deem to have a low initial quality might not be reviewed. Contributions authored fully by LLMs or generative models may be more likely to have a low initial quality.
+
+The use of generative models to assist human-authored contributions to Chickensoft is permissible. However, whether or not your code was produced using generative models, it is our practice that if maintainers don’t understand part of your code or want to know why you made a particular design decision, they may ask for an explanation or clarification as part of the review process. We ask that you have an understanding of your contribution and be able to competently discuss it.
+
 [contributor-covenant]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[chickensoft-philosophy]: https://chickensoft.games/philosophy


### PR DESCRIPTION
Added the Chickensoft policy on code quality, code review, and use of generative models in contributions to the Code-of-Conduct page.